### PR TITLE
Fix for PHP 5.6 (Moodle 3.3 minimum requirement)

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -36,7 +36,7 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return  string
      */
-    public static function get_reason() : string {
+    public static function get_reason() {
         return 'privacy:metadata';
     }
 }


### PR DESCRIPTION
I think it looks like PHP 5.6 support was broken when privacy provider support was added.  (PHP 5.6 is Moodle 3.3's minimum requirement.)  I guess it's probably not really an issue, since no-one's filed a bug report, but since it's only a small change, may as well do it anyway?