### PR TITLE
Make course link in breadcrumbs point to general section

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -264,6 +264,9 @@ class format_onetopic extends format_base {
     public function extend_course_navigation($navigation, navigation_node $node) {
         global $PAGE, $COURSE, $USER;
 
+        // Set the section number for the course node.
+        $node->action->param('section', 0);
+
         // If section is specified in course/view.php, make sure it is expanded in navigation.
         if ($navigation->includesectionnum === false) {
             $selectedsection = optional_param('section', null, PARAM_INT);


### PR DESCRIPTION
The course link in the breadcrumbs doesn't currently point to the general section.  I guess this is a side effect of Onetopic format remembering the current section number.  I tried setting the section number in the function get_view_url, but this didn't work.  Instead I've hacked it in the function extend_course_navigation, and this seems to work.