### PR TITLE
When duplicating sections, exclude deleted recources/activities

### DIFF
--- a/duplicate.php
+++ b/duplicate.php
@@ -146,7 +146,7 @@ if (!empty($sectioninfo)) {
                 $cm  = get_coursemodule_from_id('', $mod->id, 0, true, MUST_EXIST);
 
                 $modcontext = context_module::instance($cm->id);
-                if (has_capability('moodle/course:manageactivities', $modcontext)) {
+                if (has_capability('moodle/course:manageactivities', $modcontext) && !$cm->deletioninprogress) {
                     // Duplicate the module.
                     $newcm = duplicate_module($course, $cm);
 


### PR DESCRIPTION
It looks like when a section is duplicated, and it has resources/activities that have been marked for deletion, but not yet shifted to the recycle bin, these get copied too.  This is probably not desired, so this patch is to leave out deleted resources/activities.