### PR TITLE
Index sub-tab name more fixes, and first tab CSS class fix

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -324,36 +324,36 @@ class format_onetopic_renderer extends format_section_renderer_base {
                 '<innertab style="' . $customstyles . '" class="tab_content ' . $specialstyle . '">' .
                 '<span class="sectionname">' . $sectionname . "</span>" . $availablemessage . "</innertab>", $sectionname);
 
-                    if ($level == 0) {
-                        $tabs[] = $newtab;
-                        $newtab->level = 1;
-                        $parentsection = $thissection;
-                    } else {
-                        $parentindex = count($tabs) - 1;
-                        if (!is_array($tabs[$parentindex]->subtree)) {
-                            $tabs[$parentindex]->subtree = array();
-                        } else if (count($tabs[$parentindex]->subtree) == 0) {
-                            $tabs[$parentindex]->subtree[0] = clone($tabs[$parentindex]);
-                            $tabs[$parentindex]->subtree[0]->id .= '_index';
+                if ($level == 0) {
+                    $tabs[] = $newtab;
+                    $newtab->level = 1;
+                    $parentsection = $thissection;
+                } else {
+                    $parentindex = count($tabs) - 1;
+                    if (!is_array($tabs[$parentindex]->subtree)) {
+                        $tabs[$parentindex]->subtree = array();
+                    } else if (count($tabs[$parentindex]->subtree) == 0) {
+                        $tabs[$parentindex]->subtree[0] = clone($tabs[$parentindex]);
+                        $tabs[$parentindex]->subtree[0]->id .= '_index';
 
-                                $parentformatoptions = course_get_format($course)->get_format_options($parentsection);
+                        $parentformatoptions = course_get_format($course)->get_format_options($parentsection);
 
-                            if ($parentformatoptions['firsttabtext']) {
-                                $firsttabtext = $parentformatoptions['firsttabtext'];
-                            } else {
-                                $firsttabtext = get_string('index', 'format_onetopic');
-                            }
-                            $tabs[$parentindex]->subtree[0]->text = '<innertab class="tab_content tab_initial">' .
-                                                                    $firsttabtext . "</innertab>";
-                            $tabs[$parentindex]->subtree[0]->level = 2;
-
-                            if ($displaysection == $parentsection->section) {
-                                $tabs[$parentindex]->subtree[0]->selected = true;
-                            }
+                        if ($parentformatoptions['firsttabtext']) {
+                            $firsttabtext = $parentformatoptions['firsttabtext'];
+                        } else {
+                            $firsttabtext = get_string('index', 'format_onetopic');
                         }
-                        $newtab->level = 2;
-                        $tabs[$parentindex]->subtree[] = $newtab;
+                        $tabs[$parentindex]->subtree[0]->text = '<innertab class="tab_content tab_initial">' .
+                                                                $firsttabtext . "</innertab>";
+                        $tabs[$parentindex]->subtree[0]->level = 2;
+
+                        if ($displaysection == $parentsection->section) {
+                            $tabs[$parentindex]->subtree[0]->selected = true;
+                        }
                     }
+                    $newtab->level = 2;
+                    $tabs[$parentindex]->subtree[] = $newtab;
+                }
 
                 // Init move section list.
                 if ($canmove) {

--- a/renderer.php
+++ b/renderer.php
@@ -236,6 +236,7 @@ class format_onetopic_renderer extends format_section_renderer_base {
 
         // Init custom tabs.
         $section = 0;
+        $parentsection = $sections[0];
 
         $tabs = array();
         $inactivetabs = array();
@@ -276,7 +277,7 @@ class format_onetopic_renderer extends format_section_renderer_base {
                         $customstyles .= $formatoptions['cssstyles'] . ';';
                     }
 
-                    if (isset($formatoptions['level'])) {
+                    if (isset($formatoptions['level']) && count($tabs) > 0) {
                         $level = $formatoptions['level'];
                     }
                 }
@@ -323,11 +324,10 @@ class format_onetopic_renderer extends format_section_renderer_base {
                 '<innertab style="' . $customstyles . '" class="tab_content ' . $specialstyle . '">' .
                 '<span class="sectionname">' . $sectionname . "</span>" . $availablemessage . "</innertab>", $sectionname);
 
-                if (is_array($formatoptions) && isset($formatoptions['level'])) {
-
-                    if ($formatoptions['level'] == 0 || count($tabs) == 0) {
+                    if ($level == 0) {
                         $tabs[] = $newtab;
                         $newtab->level = 1;
+                        $parentsection = $thissection;
                     } else {
                         $parentindex = count($tabs) - 1;
                         if (!is_array($tabs[$parentindex]->subtree)) {
@@ -336,12 +336,7 @@ class format_onetopic_renderer extends format_section_renderer_base {
                             $tabs[$parentindex]->subtree[0] = clone($tabs[$parentindex]);
                             $tabs[$parentindex]->subtree[0]->id .= '_index';
 
-                            $prevsectionindex = $section - 1;
-                            do {
-                                $parentsection = $sections[$prevsectionindex];
                                 $parentformatoptions = course_get_format($course)->get_format_options($parentsection);
-                                $prevsectionindex--;
-                            } while ($parentformatoptions['level'] == 1 && $prevsectionindex >= 0);
 
                             if ($parentformatoptions['firsttabtext']) {
                                 $firsttabtext = $parentformatoptions['firsttabtext'];
@@ -352,16 +347,13 @@ class format_onetopic_renderer extends format_section_renderer_base {
                                                                     $firsttabtext . "</innertab>";
                             $tabs[$parentindex]->subtree[0]->level = 2;
 
-                            if ($displaysection == $section - 1) {
+                            if ($displaysection == $parentsection->section) {
                                 $tabs[$parentindex]->subtree[0]->selected = true;
                             }
                         }
                         $newtab->level = 2;
                         $tabs[$parentindex]->subtree[] = $newtab;
                     }
-                } else {
-                    $tabs[] = $newtab;
-                }
 
                 // Init move section list.
                 if ($canmove) {


### PR DESCRIPTION
Recently there was the change
Fix the index sub-tab name when childs are hidden
to address the issue
#92 Text in first child tab should always inherit from parent tab
I think there are still some problems remaining though.

When the code looks back through sections to find the previous first-level section, it ignores sections set as second-level, except section 0 (which will always be first-level regardless of setting).  I think this is mostly right, but if section 0 is visualised before the tabs, then it should also not ignore the first visible section after section 0 (this will also always be first-level regardless of setting).  Also, when the code looks back, it doesn't ignore hidden (first-level) sections, which I think it should.  To fix these, instead of looking back to find the previous first-level section, I have used the approach of remembering the most recent first-level section.  I have changed a nested if statement into a single check to avoid duplicate code (indenting is fixed in a separate change, to make the initial change more readable).

The code to determine when an index tab is selected still assumes the previous section is the parent.  To fix this, I have referred to the previously found parent section.

Unrelated, but I also noticed tabs' CSS class, as set in $specialstyle has tab_level_{$level}, where $level is the level setting, not accounting for exceptions (section 0, or first following section if section 0 is visualised before the tabs).  To fix this, I have moved the check count($tabs) == 0 earlier.