### PR TITLE
Show sidebar in Moodle 4.0

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -162,6 +162,15 @@ class format_onetopic extends format_base {
     }
 
     /**
+     * Returns true if this course format uses course index
+     *
+     * @return bool
+     */
+    public function uses_course_index() {
+        return true;
+    }
+
+    /**
      * Returns the display name of the given section that the course prefers.
      *
      * Use section name is specified by user. Otherwise use default ("Topic #")


### PR DESCRIPTION
Hi David,

I think this should re-enable the side bar in Moodle 4.0, although it removes activity navigation--apparently in Moodle 4.0 you can't have both:
https://moodle.org/mod/forum/discuss.php?d=433448
I haven't done any testing to check it doesn't break anything.

The errors aren't related to my change, it looks like there's a new style rule that some files don't need:
defined('MOODLE_INTERNAL') || die();
and it's complaining about AMD files needing to be rebuilt (I don't know much about this, not sure if there was something I could do to avoid it).