### PR TITLE
Partially revert fix delete (Moodle 3.9)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -34,7 +34,7 @@ require_once($CFG->dirroot. '/course/format/lib.php');
  * @copyright 2012 David Herney Bernal - cirano
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class format_onetopic extends core_courseformat\base {
+class format_onetopic extends format_base {
 
     /** @var int The summary is not a template */
     const TEMPLATETOPIC_NOT = 0;

--- a/renderer.php
+++ b/renderer.php
@@ -33,7 +33,7 @@ require_once($CFG->dirroot.'/course/format/renderer.php');
  * @copyright 2012 David Herney Bernal - cirano
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class format_onetopic_renderer extends core_courseformat\output\section_renderer {
+class format_onetopic_renderer extends format_section_renderer_base {
 
 
     /** @var stdClass Local format data */


### PR DESCRIPTION
Parts of the fix delete change for Moodle 4.0 aren't compatible with Moodle 3.x.