### PR TITLE
Update tabs marker and dimmed CSS rules (Moodle 4.0)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,7 @@
     text-overflow: ellipsis;
 }
 
-.format-onetopic .tab_content.marker {
+.format-onetopic .course-content ul.nav-tabs li.marker a {
     font-weight: bold;
 }
 
@@ -37,7 +37,7 @@
     margin-top: 15px;
 }
 
-.format-onetopic ul.nav-tabs li a .tab_content.dimmed .sectionname {
+.format-onetopic .course-content ul.nav-tabs li.dimmed a {
     color: #999;
     opacity: 0.5;
 }


### PR DESCRIPTION
The .tab_content.marker and .tab_content.dimmed CSS rules no longer work with the new tabs HTML. This is a small update to fix them.  (Replaces #126, which was on the wrong branch.)