### PR TITLE
Fix delete (Moodle 4.0)

### DIFF
--- a/classes/output/courseformat/content/section/controlmenu.php
+++ b/classes/output/courseformat/content/section/controlmenu.php
@@ -98,6 +98,16 @@ class controlmenu extends controlmenu_base {
 
         $parentcontrols = parent::section_control_items();
 
+        if (array_key_exists("delete", $parentcontrols)) {
+            $url = new \moodle_url('/course/editsection.php', array(
+                'id' => $section->id,
+                'sr' => $section->section - 1,
+                'delete' => 1,
+                'sesskey' => sesskey()));
+            $parentcontrols['delete']['url'] = $url;
+            unset($parentcontrols['delete']['attr']['data-action']);
+        }
+
         // If the edit key exists, we are going to insert our controls after it.
         if (array_key_exists("edit", $parentcontrols)) {
             $merged = [];


### PR DESCRIPTION
When deleting a section, the page sometimes doesn't get updated, making it look like the section wasn't deleted.  This seems to be an issue with Moodle, not the Onetopic format.  As a workaround, this reapplies #117 to the new code, forcing a full page reload.