### PR TITLE
Dim the tabs bar if it's hidden from students (Moodle 4.0)

### DIFF
--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -284,10 +284,10 @@ class content extends content_base {
                     $specialclass .= ' marker ';
                 }
 
-                if (!$thissection->visible || !$thissection->available) {
+                if (!$thissection->visible || !$thissection->available || $course->hidetabsbar) {
                     $specialclass .= ' dimmed disabled ';
 
-                    if (!$canviewhidden) {
+                    if (!$thissection->uservisible) {
                         $inactivetab = true;
                     }
                 }


### PR DESCRIPTION
It may be confusing for teachers if they have edit mode on and hide the tabs bar, because it doesn't look like anything changed.  The downside with this, though, is that you can't tell from the tabs bar which sections are hidden.  (Depends on #127.)