### PR TITLE
Fix tab class tab_level (Moodle 4.0)

### DIFF
--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -268,7 +268,7 @@ class content extends content_base {
                         $customstyles .= $formatoptions['cssstyles'] . '; ';
                     }
 
-                    if (isset($formatoptions['level'])) {
+                    if (isset($formatoptions['level']) && $section > $firstsection) {
                         $level = $formatoptions['level'];
                     }
                 }


### PR DESCRIPTION
Currently, if the first tab (section 0 if shown as a tab, or section 1 otherwise) is set to be a child tab, it's HTML class is set to tab_level_1, even though it's shown as a top-level tab.