### PR TITLE
Run code checks against Moodle 4.1

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -31,9 +31,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4', '8.0']
-        moodle-branch: ['MOODLE_400_STABLE']
-        database: [pgsql, mariadb]
+        include:
+          # Moodle 4.0, PHP 7.3, PostgreSQL
+          - php: '7.3' # 7.3-8.0
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: pgsql
+          # Moodle 4.1, PHP 7.4, MariaDB
+          - php: '7.4' # 7.4-8.0
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+          # Moodle 4.1, PHP 8.0, PostgreSQL
+          - php: '8.0' # 7.4-8.0
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
Moodle now has a branch for Moodle 4.1, and it doesn't seem to require recompiling AMD currently, so maybe plugins can support Moodle 4.0 and 4.1 on one branch.  While it's good to check against every Moodle version, PHP version, and database, it's probably not necessary to check against every combination of them, and it's not possible with Moodle 4.0 and 4.1, since 4.0 supports PHP 7.3, and Moodle 4.1 doesn't.