### PR TITLE
Code checker updates for PHP 8.1 and Moodle 4.2

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12 # Moodle 4.0: >= 10
+        image: postgres:13 # Moodle 4.2: >= 13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -18,7 +18,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
-        image: mariadb:10.5 # Moodle 4.0 >=10.2.29
+        image: mariadb:10.6 # Moodle 4.2 >=10.6.7
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -37,11 +37,15 @@ jobs:
             moodle-branch: 'MOODLE_400_STABLE'
             database: pgsql
           # Moodle 4.1, PHP 7.4, MariaDB
-          - php: '7.4' # 7.4-8.0
+          - php: '7.4' # 7.4-8.1
             moodle-branch: 'MOODLE_401_STABLE'
             database: mariadb
           # Moodle 4.1, PHP 8.0, PostgreSQL
-          - php: '8.0' # 7.4-8.0
+          - php: '8.0' # 7.4-8.1
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+          # Moodle 4.1, PHP 8.1, PostgreSQL
+          - php: '8.1' # 7.4-8.1
             moodle-branch: 'MOODLE_401_STABLE'
             database: pgsql
 

--- a/classes/output/courseformat/content/section/summary.php
+++ b/classes/output/courseformat/content/section/summary.php
@@ -139,7 +139,7 @@ class summary extends summary_base {
         $completioninfo = new \completion_info($course);
 
         if (!isset($initialised)) {
-            $groupbuttons     = ($course->groupmode || (!$course->groupmodeforce));
+            $groupbuttons = ($course->groupmode || (!$course->groupmodeforce));
             $groupbuttonslink = (!$course->groupmodeforce);
             include_once($CFG->dirroot . '/mod/forum/lib.php');
             if ($usetracking = forum_tp_can_track_forums()) {
@@ -157,7 +157,7 @@ class summary extends summary_base {
         $summary = $section->summary;
 
         $htmlresource = '';
-        $htmlmore     = '';
+        $htmlmore = '';
 
         if (!empty($section->sequence)) {
             $sectionmods = explode(",", $section->sequence);

--- a/duplicate.php
+++ b/duplicate.php
@@ -166,7 +166,7 @@ if (!empty($sectioninfo)) {
             foreach ($sectionmods as $modnumber) {
                 $k++;
                 $mod = $modinfo->cms[$modnumber];
-                $cm  = get_coursemodule_from_id('', $mod->id, 0, true, MUST_EXIST);
+                $cm = get_coursemodule_from_id('', $mod->id, 0, true, MUST_EXIST);
 
                 $modcontext = context_module::instance($cm->id);
                 if (has_capability('moodle/course:manageactivities', $modcontext) && !$cm->deletioninprogress) {

--- a/templates/local/content.mustache
+++ b/templates/local/content.mustache
@@ -32,6 +32,7 @@
                                 "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Forum example</span></a>",
                                 "hasname": "true"
                             },
+                            "cmid": 3,
                             "id": 3,
                             "anchor": "module-3",
                             "module": "forum",
@@ -86,6 +87,7 @@
                                 "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Assign example</span></a>",
                                 "hasname": "true"
                             },
+                            "cmid": 4,
                             "id": 4,
                             "anchor": "module-4",
                             "module": "assign",

--- a/templates/local/content/section.mustache
+++ b/templates/local/content/section.mustache
@@ -41,6 +41,7 @@
                             "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Forum example</span></a>",
                             "hasname": "true"
                         },
+                        "cmid": 3,
                         "id": 3,
                         "module": "forum",
                         "anchor": "activity-3",
@@ -53,6 +54,7 @@
                             "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Assign example</span></a>",
                             "hasname": "true"
                         },
+                        "cmid": 4,
                         "id": 4,
                         "anchor": "activity-4",
                         "module": "assign",

--- a/templates/local/content/section/content.mustache
+++ b/templates/local/content/section/content.mustache
@@ -38,6 +38,7 @@
                             "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Forum example</span></a>",
                             "hasname": "true"
                         },
+                        "cmid": 3,
                         "id": 3,
                         "module": "forum",
                         "anchor": "activity-3",
@@ -50,6 +51,7 @@
                             "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Assign example</span></a>",
                             "hasname": "true"
                         },
+                        "cmid": 4,
                         "id": 4,
                         "anchor": "activity-4",
                         "module": "assign",

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version = 2022081607;       // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2022041902;        // Requires this Moodle version.
+$plugin->requires = 2022041902;         // Requires this Moodle version.
 $plugin->component = 'format_onetopic'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.1.03(PiedrasTeherán)';


### PR DESCRIPTION
A variety of things are updated for the code checker:
- PHP 8.1 is now supported by Moodle (see MDL-73016).
- Moodle 4.2 system requirements have been decided (see MDL-74905), and Postgres and MariaDB requirements have increased.
- The code checker now requires single spaces around the assignment operator.
- Moodle 4.2 requires the cmid property in Mustache templates.