### PR TITLE
Code checker updates, including for Moodle 4.2

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13 # Moodle 4.2: >= 13
+        image: postgres:13 # Moodle 4.2: >=13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -18,7 +18,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
-        image: mariadb:10.6 # Moodle 4.2 >=10.6.7
+        image: mariadb:10.6 # Moodle 4.2: >=10.6.7
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -36,22 +36,26 @@ jobs:
           - php: '7.3' # 7.3-8.0
             moodle-branch: 'MOODLE_400_STABLE'
             database: pgsql
+            plugin-ci: ^3
           # Moodle 4.1, PHP 7.4, MariaDB
           - php: '7.4' # 7.4-8.1
             moodle-branch: 'MOODLE_401_STABLE'
             database: mariadb
-          # Moodle 4.1, PHP 8.0, PostgreSQL
-          - php: '8.0' # 7.4-8.1
-            moodle-branch: 'MOODLE_401_STABLE'
+            plugin-ci: ^4
+          # Moodle 4.2, PHP 8.0, PostgreSQL
+          - php: '8.0' # 8.0-8.1
+            moodle-branch: 'MOODLE_402_STABLE'
             database: pgsql
-          # Moodle 4.1, PHP 8.1, PostgreSQL
-          - php: '8.1' # 7.4-8.1
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: pgsql
+            plugin-ci: ^4
+          # Moodle 4.2, PHP 8.1, MariaDB
+          - php: '8.1' # 8.0-8.1
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: mariadb
+            plugin-ci: ^4
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: plugin
 
@@ -61,11 +65,13 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
           ini-values: max_input_vars=5000
+          # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
+          # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
           coverage: none
 
       - name: Initialise moodle-plugin-ci
         run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ${{ matrix.plugin-ci }}
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
@@ -94,7 +100,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 0
+        run: moodle-plugin-ci phpcs --max-warnings 0
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}


### PR DESCRIPTION
Moodle 4.2 is released, so that can be checked now.
There is a new version of the CI plugin, but it doesn't support PHP 7.3, so the old version needs to be used for checking PHP 7.3.  See https://moodlehq.github.io/moodle-plugin-ci/UPGRADE-4.0.html
I thought maybe it would be good to alternate between checking PostgreSQL and MariaDB.
GitHub has updated their checkout code, so that needs to be changed.  See https://github.com/moodlehq/moodle-plugin-ci/pull/190
The example CI script changed the command for calling the code checker, so may as well do that.  See https://github.com/moodlehq/moodle-plugin-ci/pull/212
May as well include the comment that's been added to the example CI script too.