### PR TITLE
Update section control menu for Moodle 4.2

### DIFF
--- a/classes/output/courseformat/content/section/controlmenu.php
+++ b/classes/output/courseformat/content/section/controlmenu.php
@@ -103,7 +103,8 @@ class controlmenu extends controlmenu_base {
         }
 
         // Duplicate current section option.
-        if ($section->section && has_capability('moodle/course:manageactivities', $coursecontext)) {
+        if ($section->section && has_capability('moodle/course:update', $coursecontext)
+                && has_capability('moodle/course:manageactivities', $coursecontext)) {
             $duplicatesectionurl = new \moodle_url('/course/format/onetopic/duplicate.php',
                             ['courseid' => $course->id, 'section' => $section->section, 'sesskey' => sesskey()]);
 
@@ -114,6 +115,8 @@ class controlmenu extends controlmenu_base {
                 'pixattr' => ['class' => ''],
                 'attr' => ['class' => 'editing_duplicate'],
             ];
+        } else if (array_key_exists('duplicate', $parentcontrols)) {
+            unset($parentcontrols['duplicate']);
         }
 
         if ($section->section && !$isstealth && has_capability('moodle/course:movesections', $coursecontext, $USER)) {


### PR DESCRIPTION
Moodle 4.2 adds a duplicate section option, which is currently buggy, and, as the Onetopic section control menu merging code currently works, overwrites Onetopic's working duplicate section option.  I guess it would be better to use Onetopic's duplicate section option.  Rather than just change the section control menu merging code to support this one new case, I've rewritten it to make it more extensible in the future.  I'm not sure if this is overkill.  There are a couple of other changes too:
- Change Onetopic's duplicate icon to match Moodle 4.2's.
- Change Moodle 4.2's permalink to something that works for Onetopic.