### PR TITLE
fixed endless redirects

### DIFF
--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -344,10 +344,6 @@ class content extends content_base {
         $displaysection = $this->format->get_section_number();
         $enablecustomstyles = get_config('format_onetopic', 'enablecustomstyles');
 
-        // Can we view the section in question?
-        $context = \context_course::instance($course->id);
-        $canviewhidden = has_capability('moodle/course:viewhiddensections', $context);
-
         // Init custom tabs.
         $section = 0;
 
@@ -366,12 +362,8 @@ class content extends content_base {
 
             $thissection = $sections[$section];
 
-            $showsection = true;
-            if (!$thissection->visible || !$thissection->available) {
-                $showsection = $canviewhidden || !($course->hiddensections == 1);
-            }
-
-            if ($showsection) {
+            // Can we view the section in question?
+            if ($thissection->uservisible || $course->hiddensections != 1) {
 
                 $formatoptions = course_get_format($course)->get_format_options($thissection);
 
@@ -419,7 +411,7 @@ class content extends content_base {
                 if (!$thissection->visible || !$thissection->available) {
                     $specialclass .= ' dimmed disabled ';
 
-                    if (!$canviewhidden) {
+                    if (!$thissection->uservisible) {
                         $inactivetab = true;
                     }
                 }

--- a/lib.php
+++ b/lib.php
@@ -133,14 +133,11 @@ class format_onetopic extends core_courseformat\base {
                 $realsection = 1;
             }
 
-            // Can view the hidden sections in current course?
-            $canviewhidden = has_capability('moodle/course:viewhiddensections', $context);
-
             $modinfo = get_fast_modinfo($course);
             $sections = $modinfo->get_section_info_all();
 
             // Check if the display section is available.
-            if ((!$canviewhidden && (!$sections[$realsection]->uservisible || !$sections[$realsection]->available))) {
+            if (!$sections[$realsection]->uservisible) {
 
                 self::$formatmsgs[] = get_string('hidden_message', 'format_onetopic', $this->get_section_name($realsection));
 
@@ -150,8 +147,7 @@ class format_onetopic extends core_courseformat\base {
                 do {
                     $formatoptions = $this->get_format_options($k);
                     if ($formatoptions['level'] == 0
-                            && ($sections[$k]->available && $sections[$k]->uservisible)
-                            || $canviewhidden) {
+                            && $sections[$k]->uservisible) {
                         $valid = true;
                         break;
                     }


### PR DESCRIPTION
in case the section is unavailable (i.e. has availability restrictions that are not met) but the user can view hidden sections (i.e. has 'moodle/course:viewhiddensections'

Fixes #155