### PR TITLE
Code checker updates: Short array syntax and more

### DIFF
--- a/changenumsections.php
+++ b/changenumsections.php
@@ -35,10 +35,10 @@ $returnurl = optional_param('returnurl', null, PARAM_LOCALURL);    // Where to r
 $sectionreturn = optional_param('sectionreturn', null, PARAM_INT); // Section to return to, ignored if $returnurl is specified.
 $aschild = optional_param('aschild', 0, PARAM_BOOL);               // It is created as child.
 
-$course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+$course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
 $courseformatoptions = course_get_format($course)->get_format_options();
 
-$PAGE->set_url('/course/format/onetopic/changenumsections.php', array('courseid' => $courseid));
+$PAGE->set_url('/course/format/onetopic/changenumsections.php', ['courseid' => $courseid]);
 // Authorisation checks.
 require_login($course);
 require_capability('moodle/course:update', context_course::instance($course->id));
@@ -81,8 +81,8 @@ if (isset($courseformatoptions['numsections']) && $increase !== null) {
     // Don't go less than 0, intentionally redirect silently (for the case of
     // double clicks).
     if ($courseformatoptions['numsections'] >= 0) {
-        update_course((object)array('id' => $course->id,
-            'numsections' => $courseformatoptions['numsections']));
+        update_course((object)['id' => $course->id,
+            'numsections' => $courseformatoptions['numsections'], ]);
     }
     if (!$returnurl) {
         $returnurl = course_get_url($course);
@@ -100,7 +100,7 @@ if (isset($courseformatoptions['numsections']) && $increase !== null) {
 
         if ($aschild) {
             // Set level to one because it is a child tab.
-            $courseformat->update_section_format_options(array('level' => 1, 'id' => $section->id));
+            $courseformat->update_section_format_options(['level' => 1, 'id' => $section->id]);
         }
     }
     if (!$returnurl) {

--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -406,7 +406,7 @@ class content extends content_base {
                 }
 
                 if ($section == 0) {
-                    $url = new \moodle_url('/course/view.php', array('id' => $course->id, 'section' => 0));
+                    $url = new \moodle_url('/course/view.php', ['id' => $course->id, 'section' => 0]);
                 } else {
                     $url = course_get_url($course, $section);
                 }
@@ -515,10 +515,10 @@ class content extends content_base {
                 $icon = $output->pix_icon('t/switch_plus', s($straddsection));
                 $insertposition = $displaysection + 1;
 
-                $paramstotabs = array('courseid' => $course->id,
-                                    'increase' => true,
-                                    'sesskey' => sesskey(),
-                                    'insertsection' => $insertposition);
+                $paramstotabs = ['courseid' => $course->id,
+                                'increase' => true,
+                                'sesskey' => sesskey(),
+                                'insertsection' => $insertposition, ];
 
                 // Define if subtabs are displayed (a subtab is selected or the selected tab has subtabs).
                 $selectedsubtabs = $selectedparent ? $tabs->get_tab($selectedparent->index) : null;

--- a/classes/output/courseformat/content/section.php
+++ b/classes/output/courseformat/content/section.php
@@ -44,7 +44,7 @@ class section extends section_base {
      * Export this data so it can be used as the context for a mustache template.
      *
      * @param renderer_base $output typically, the renderer that's calling this function
-     * @return array data context for a mustache template
+     * @return stdClass data context for a mustache template
      */
     public function export_for_template(\renderer_base $output): stdClass {
         global $USER, $PAGE;
@@ -63,7 +63,7 @@ class section extends section_base {
             'summary' => $summary->export_for_template($output),
             'highlightedlabel' => $format->get_section_highlighted_name(),
             'sitehome' => $course->id == SITEID,
-            'editing' => $PAGE->user_is_editing()
+            'editing' => $PAGE->user_is_editing(),
         ];
 
         $haspartials = [];

--- a/classes/output/courseformat/content/section/cmlist.php
+++ b/classes/output/courseformat/content/section/cmlist.php
@@ -46,7 +46,7 @@ class cmlist extends cmlist_base {
      * Export this data so it can be used as the context for a mustache template.
      *
      * @param renderer_base $output typically, the renderer that's calling this function
-     * @return array data context for a mustache template
+     * @return stdClass data context for a mustache template
      */
     public function export_for_template(\renderer_base $output): stdClass {
         global $USER;
@@ -99,7 +99,7 @@ class cmlist extends cmlist_base {
                 $item = new $this->itemclass($format, $section, $mod, $this->displayoptions);
                 $data->cms[] = (object)[
                     'cmitem' => $item->export_for_template($output),
-                    'moveurl' => new moodle_url('/course/mod.php', array('moveto' => $modnumber, 'sesskey' => sesskey())),
+                    'moveurl' => new moodle_url('/course/mod.php', ['moveto' => $modnumber, 'sesskey' => sesskey()]),
                 ];
             }
         }

--- a/classes/output/courseformat/content/section/controlmenu.php
+++ b/classes/output/courseformat/content/section/controlmenu.php
@@ -80,7 +80,7 @@ class controlmenu extends controlmenu_base {
                     'pixattr' => ['class' => ''],
                     'attr' => [
                         'class' => 'editing_highlight',
-                        'data-action' => 'removemarker'
+                        'data-action' => 'removemarker',
                     ],
                 ];
             } else {
@@ -93,7 +93,7 @@ class controlmenu extends controlmenu_base {
                     'pixattr' => ['class' => ''],
                     'attr' => [
                         'class' => 'editing_highlight',
-                        'data-action' => 'setmarker'
+                        'data-action' => 'setmarker',
                     ],
                 ];
             }
@@ -147,7 +147,7 @@ class controlmenu extends controlmenu_base {
                 'name' => get_string('duplicate', 'format_onetopic'),
                 'pixattr' => ['class' => ''],
                 'attr' => [
-                    'class' => 'editing_duplicate'
+                    'class' => 'editing_duplicate',
                 ],
             ];
         }
@@ -160,7 +160,7 @@ class controlmenu extends controlmenu_base {
                 'id' => $section->id,
                 'sr' => $section->section - 1,
                 'delete' => 1,
-                'sesskey' => sesskey()]);
+                'sesskey' => sesskey(), ]);
             $parentcontrols['delete']['url'] = $url;
             unset($parentcontrols['delete']['attr']['data-action']);
         }

--- a/classes/output/courseformat/content/section/summary.php
+++ b/classes/output/courseformat/content/section/summary.php
@@ -78,7 +78,7 @@ class summary extends summary_base {
      * Export this data so it can be used as the context for a mustache template.
      *
      * @param renderer_base $output typically, the renderer that's calling this function
-     * @return array data context for a mustache template
+     * @return stdClass data context for a mustache template
      */
     public function export_for_template(\renderer_base $output): stdClass {
 
@@ -227,7 +227,7 @@ class summary extends summary_base {
                 $this->tplstringsearch = $instancename;
 
                 $newsummary = preg_replace_callback("/(\[\[)(([<][^>]*>)*)((" . preg_quote($this->tplstringsearch, '/') .
-                    ")(:?))([^\]]*)\]\]/i", array($this, "replace_tag_in_expresion"), $summary);
+                    ")(:?))([^\]]*)\]\]/i", [$this, "replace_tag_in_expresion"], $summary);
 
                 if ($newsummary != $summary) {
                     $this->format->tplcmsused[] = $modnumber;

--- a/classes/tabs.php
+++ b/classes/tabs.php
@@ -41,7 +41,7 @@ class tabs {
      *
      */
     public function __construct() {
-        $this->tabslist = array();
+        $this->tabslist = [];
     }
 
     /**

--- a/duplicate.php
+++ b/duplicate.php
@@ -30,7 +30,7 @@ require_once($CFG->dirroot.'/course/lib.php');
 $courseid = required_param('courseid', PARAM_INT);
 $section = required_param('section', PARAM_INT);
 
-$course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+$course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
 
 $urlstring = '/course/format/onetopic/duplicate.php';
 $PAGE->set_url($urlstring, ['courseid' => $courseid, 'section' => $section]);
@@ -73,7 +73,7 @@ if (!$confirm) {
 $PAGE->set_pagelayout('course');
 $PAGE->set_heading($course->fullname);
 
-$PAGE->set_title(get_string('coursetitle', 'moodle', array('course' => $course->fullname)));
+$PAGE->set_title(get_string('coursetitle', 'moodle', ['course' => $course->fullname]));
 
 echo $OUTPUT->header();
 
@@ -84,7 +84,7 @@ if (!empty($sectioninfo)) {
 
     $courseformat = course_get_format($course);
 
-    $lastsectionnum = $DB->get_field('course_sections', 'MAX(section)', array('course' => $courseid), MUST_EXIST);
+    $lastsectionnum = $DB->get_field('course_sections', 'MAX(section)', ['course' => $courseid], MUST_EXIST);
 
     $numnewsection = $lastsectionnum + 1;
 
@@ -109,11 +109,11 @@ if (!empty($sectioninfo)) {
         if ($files && is_array($files)) {
             foreach ($files as $f) {
 
-                $fileinfo = array(
+                $fileinfo = [
                     'contextid' => $context->id,
                     'component' => 'course',
                     'filearea' => 'section',
-                    'itemid' => $newsectionid);
+                    'itemid' => $newsectionid, ];
 
                 $fs->create_file_from_storedfile($fileinfo, $f);
             }
@@ -135,12 +135,12 @@ if (!empty($sectioninfo)) {
 
     // Trigger an event for course section update.
     $event = \core\event\course_section_updated::create(
-            array(
+            [
                 'objectid' => $newsectionid,
                 'courseid' => $course->id,
                 'context' => $context,
-                'other' => array('sectionnum' => $numnewsection)
-            )
+                'other' => ['sectionnum' => $numnewsection],
+            ]
         );
     $event->trigger();
 
@@ -150,7 +150,7 @@ if (!empty($sectioninfo)) {
     $pbar->update_full(10, get_string('rebuild_course_cache', 'format_onetopic'));
     $newsectioninfo = $modinfo->get_section_info($numnewsection);
 
-    $modules = array();
+    $modules = [];
 
     if (is_object($modinfo) && isset($modinfo->sections[$section])) {
         $sectionmods = $modinfo->sections[$section];

--- a/format.php
+++ b/format.php
@@ -56,12 +56,10 @@ $renderer = $PAGE->get_renderer('format_onetopic');
 
 $section = $displaysection;
 
-$renderer->numsections = course_get_format($course)->get_last_section_number();
-
 $disableajax = optional_param('onetopic_da', -1, PARAM_INT);
 
 if (!isset($USER->onetopic_da)) {
-    $USER->onetopic_da = array();
+    $USER->onetopic_da = [];
 }
 
 if ($disableajax !== -1) {
@@ -85,11 +83,11 @@ $PAGE->requires->js('/course/format/topics/format.js');
 $PAGE->requires->js('/course/format/onetopic/format.js');
 $PAGE->requires->yui_module('moodle-core-notification-dialogue', 'M.course.format.dialogueinit');
 
-$params = array(
+$params = [
     'formattype' => $course->tabsview,
     'icons' => [
         'left' => $OUTPUT->pix_icon('t/collapsed_rtl', ''),
         'right' => $OUTPUT->pix_icon('t/collapsed', ''),
-    ]
-);
+    ],
+];
 $PAGE->requires->js_call_amd('format_onetopic/main', 'init', $params);

--- a/lib.php
+++ b/lib.php
@@ -434,36 +434,36 @@ class format_onetopic extends core_courseformat\base {
             $courseformatoptions = [
                 'hiddensections' => [
                     'default' => $courseconfig->hiddensections,
-                    'type' => PARAM_INT
+                    'type' => PARAM_INT,
                 ],
                 'hidetabsbar' => [
                     'default' => 0,
-                    'type' => PARAM_INT
+                    'type' => PARAM_INT,
                 ],
                 'coursedisplay' => [
                     'default' => $courseconfig->coursedisplay,
-                    'type' => PARAM_INT
+                    'type' => PARAM_INT,
                 ],
                 'templatetopic' => [
                     'default' => self::TEMPLATETOPIC_NOT,
-                    'type' => PARAM_INT
+                    'type' => PARAM_INT,
                 ],
                 'templatetopic_icons' => [
                     'default' => 0,
-                    'type' => PARAM_INT
+                    'type' => PARAM_INT,
                 ],
                 'tabsview' => [
                     'default' => 0,
-                    'type' => PARAM_INT
+                    'type' => PARAM_INT,
                 ],
                 'usessectionsnavigation' => [
                     'default' => 0,
-                    'type' => PARAM_INT
+                    'type' => PARAM_INT,
                 ],
                 'usescourseindex' => [
                     'default' => 2,
-                    'type' => PARAM_INT
-                ]
+                    'type' => PARAM_INT,
+                ],
             ];
         }
 
@@ -478,8 +478,8 @@ class format_onetopic extends core_courseformat\base {
                         [
                             0 => new lang_string('hiddensectionscollapsed'),
                             1 => new lang_string('hiddensectionsinvisible'),
-                            2 => new lang_string('hiddensectionshelp', 'format_onetopic')
-                        ]
+                            2 => new lang_string('hiddensectionshelp', 'format_onetopic'),
+                        ],
                     ],
                 ],
                 'hidetabsbar' => [
@@ -490,8 +490,8 @@ class format_onetopic extends core_courseformat\base {
                     'element_attributes' => [
                         [
                             0 => new lang_string('no'),
-                            1 => new lang_string('yes')
-                        ]
+                            1 => new lang_string('yes'),
+                        ],
                     ],
                 ],
                 'coursedisplay' => [
@@ -500,8 +500,8 @@ class format_onetopic extends core_courseformat\base {
                     'element_attributes' => [
                         [
                             COURSE_DISPLAY_SINGLEPAGE => new lang_string('coursedisplay_single', 'format_onetopic'),
-                            COURSE_DISPLAY_MULTIPAGE => new lang_string('coursedisplay_multi', 'format_onetopic')
-                        ]
+                            COURSE_DISPLAY_MULTIPAGE => new lang_string('coursedisplay_multi', 'format_onetopic'),
+                        ],
                     ],
                     'help' => 'coursedisplay',
                     'help_component' => 'format_onetopic',
@@ -513,8 +513,8 @@ class format_onetopic extends core_courseformat\base {
                         [
                             self::TEMPLATETOPIC_NOT => new lang_string('templetetopic_not', 'format_onetopic'),
                             self::TEMPLATETOPIC_SINGLE => new lang_string('templetetopic_single', 'format_onetopic'),
-                            self::TEMPLATETOPIC_LIST => new lang_string('templetetopic_list', 'format_onetopic')
-                        ]
+                            self::TEMPLATETOPIC_LIST => new lang_string('templetetopic_list', 'format_onetopic'),
+                        ],
                     ],
                     'help' => 'templatetopic',
                     'help_component' => 'format_onetopic',
@@ -527,8 +527,8 @@ class format_onetopic extends core_courseformat\base {
                     'element_attributes' => [
                         [
                             0 => new lang_string('no'),
-                            1 => new lang_string('yes')
-                        ]
+                            1 => new lang_string('yes'),
+                        ],
                     ],
                 ],
                 'tabsview' => [
@@ -538,8 +538,8 @@ class format_onetopic extends core_courseformat\base {
                         [
                             self::TABSVIEW_DEFAULT => new lang_string('tabsview_default', 'format_onetopic'),
                             self::TABSVIEW_VERTICAL => new lang_string('tabsview_vertical', 'format_onetopic'),
-                            self::TABSVIEW_ONELINE => new lang_string('tabsview_oneline', 'format_onetopic')
-                        ]
+                            self::TABSVIEW_ONELINE => new lang_string('tabsview_oneline', 'format_onetopic'),
+                        ],
                     ],
                     'help' => 'tabsview',
                     'help_component' => 'format_onetopic',
@@ -555,7 +555,7 @@ class format_onetopic extends core_courseformat\base {
                             self::SECTIONSNAVIGATION_BOTTOM => new lang_string('sectionsnavigation_bottom', 'format_onetopic'),
                             self::SECTIONSNAVIGATION_BOTH => new lang_string('sectionsnavigation_both', 'format_onetopic'),
                             self::SECTIONSNAVIGATION_SLIDES => new lang_string('sectionsnavigation_slides', 'format_onetopic'),
-                        ]
+                        ],
                     ],
                     'help' => 'usessectionsnavigation',
                     'help_component' => 'format_onetopic',
@@ -570,9 +570,9 @@ class format_onetopic extends core_courseformat\base {
                             2 => new lang_string('usecourseindexsite', 'format_onetopic'),
                             0 => new lang_string('no'),
                             1 => new lang_string('yes'),
-                        ]
+                        ],
                     ],
-                ]
+                ],
             ];
             $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);
         }
@@ -687,28 +687,28 @@ class format_onetopic extends core_courseformat\base {
             $sectionformatoptions = [
                 'level' => [
                     'default' => 0,
-                    'type' => PARAM_INT
+                    'type' => PARAM_INT,
                 ],
                 'firsttabtext' => [
                     'default' => get_string('index', 'format_onetopic'),
-                    'type' => PARAM_TEXT
-                ]
+                    'type' => PARAM_TEXT,
+                ],
             ];
 
             if ($enablecustomstyles) {
                 $sectionformatoptions['fontcolor'] = [
                     'default' => '',
-                    'type' => PARAM_RAW
+                    'type' => PARAM_RAW,
                 ];
 
                 $sectionformatoptions['bgcolor'] = [
                     'default' => '',
-                    'type' => PARAM_RAW
+                    'type' => PARAM_RAW,
                 ];
 
                 $sectionformatoptions['cssstyles'] = [
                     'default' => '',
-                    'type' => PARAM_RAW
+                    'type' => PARAM_RAW,
                 ];
             }
         }
@@ -723,8 +723,8 @@ class format_onetopic extends core_courseformat\base {
                     'element_attributes' => [
                         [
                             0 => get_string('asprincipal', 'format_onetopic'),
-                            1 => get_string('aschild', 'format_onetopic')
-                        ]
+                            1 => get_string('aschild', 'format_onetopic'),
+                        ],
                         ],
                     'help' => 'level',
                     'help_component' => 'format_onetopic',
@@ -735,7 +735,7 @@ class format_onetopic extends core_courseformat\base {
                     'label' => get_string('firsttabtext', 'format_onetopic'),
                     'help' => 'firsttabtext',
                     'help_component' => 'format_onetopic',
-                ]
+                ],
             ];
 
             if ($enablecustomstyles) {


### PR DESCRIPTION
This contains several code checker updates:
- Short array syntax is now required
- Multi-line arrays should have trailing commas
- Return type mismatches
- The property renderer->numsections gives a warning in PHP 8.2, because it's not declared, and it appears no longer used

There's also an error for Moodle 4.3 with course/templates/completion_automatic.mustache now containing divs instead of spans, that I haven't addressed.  I don't know if there's any way around this other than making a modified copy of the file.