### PR TITLE
MBS-8922: Additional highlighting for active tab

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -243,6 +243,10 @@
     max-width: calc(100% - 210px);
 }
 
+.format-onetopic #tabs-tree-start .nav-tabs .nav-link.active {
+    box-shadow: 0 -5px 0 0 currentColor inset;
+}
+
 /* Tab styles configuration */
 #onetopic-tabstyles .tabstyleset-buttons button {
     margin-bottom: 10px;


### PR DESCRIPTION
This fixes #161: The current section is additionally highlighted by a box-shadow at the bottom in the same color, the text has set:

![grafik](https://github.com/davidherney/moodle-format_onetopic/assets/26581385/4192b8ac-58a7-412b-b409-9bde91ce0239)
