### PR TITLE
Quick patch for Moodle 4.4

### DIFF
--- a/classes/header.php
+++ b/classes/header.php
@@ -154,7 +154,9 @@ class header implements \renderable, \templatable {
         ];
 
         // Include course format js module.
-        $PAGE->requires->js('/course/format/topics/format.js');
+        if ($CFG->version < 2023121500) {
+            $PAGE->requires->js('/course/format/topics/format.js');
+        }
         $PAGE->requires->js('/course/format/onetopic/format.js');
         $PAGE->requires->yui_module('moodle-core-notification-dialogue', 'M.course.format.dialogueinit');
         $PAGE->requires->js_call_amd('format_onetopic/main', 'init', $params);

--- a/classes/output/courseformat/content/section.php
+++ b/classes/output/courseformat/content/section.php
@@ -70,6 +70,10 @@ class section extends section_base {
         $haspartials['availability'] = $this->add_availability_data($data, $output);
         $haspartials['visibility'] = $this->add_visibility_data($data, $output);
         $haspartials['editor'] = $this->add_editor_data($data, $output);
+        if ($haspartials['editor'] && !isset($data->control_menu) && empty($this->hidecontrols)) {
+            $controlmenu = new $this->controlmenuclass($this->format, $this->section);
+            $data->controlmenu = $controlmenu->export_for_template($output);
+        }
         $haspartials['header'] = $this->add_header_data($data, $output);
         $haspartials['cm'] = $this->add_cm_data($data, $output);
         $this->add_format_data($data, $haspartials, $output);


### PR DESCRIPTION
This is NOT a proper update for Moodle 4.4.  Moodle 4.4 seems to have quite a lot of changes in it, and several cause issues for the current Onetopic format.  I wouldn't recommend anyone using Onetopic format upgrade to Moodle 4.4 at the moment.  If you really have to, though, perhaps this patch will be enough to get by.  I just threw it together as a quick fix for a couple of big issues I noticed.