### PR TITLE
Use standard Moodle section restriction behaviour

### DIFF
--- a/templates/local/content/section.mustache
+++ b/templates/local/content/section.mustache
@@ -105,11 +105,6 @@
         data-id="{{id}}"
         data-number="{{num}}"
     >
-        {{#restrictionlock}}
-            <div class="align-self-center ml-2">
-                {{#pix}}t/unlock, core{{/pix}}
-            </div>
-        {{/restrictionlock}}
         <div data-region="sectionbadges" class="sectionbadges d-flex align-items-center">
             {{$ core_courseformat/local/content/section/badges }}
                 {{> core_courseformat/local/content/section/badges }}

--- a/templates/local/content/section/content.mustache
+++ b/templates/local/content/section/content.mustache
@@ -85,11 +85,6 @@
         "highlightedlabel" : "Highlighted"
     }
 }}
-{{#restrictionlock}}
-    <div class="align-self-center ml-2">
-        {{#pix}}t/unlock, core{{/pix}}
-    </div>
-{{/restrictionlock}}
 {{#collapsemenu}}
     {{^displayonesection}}
     <div class="flex-fill d-flex justify-content-end mr-2 align-self-start mt-2">
@@ -117,9 +112,9 @@
             {{/ core_courseformat/local/content/section/summary }}
         {{/summary}}
         {{#availability}}
-            {{$ format_onetopic/courseformat/content/cm/availabilityinline }}
-                {{> format_onetopic/courseformat/content/cm/availabilityinline }}
-            {{/ format_onetopic/courseformat/content/cm/availabilityinline }}
+            {{$ core_courseformat/local/content/section/availability }}
+                {{> core_courseformat/local/content/section/availability }}
+            {{/ core_courseformat/local/content/section/availability }}
         {{/availability}}
     </div>
     {{#cmsummary}}


### PR DESCRIPTION
When a section has access restrictions applied, two padlocks are shown on the page, but no details of the restriction.  This restores standard Moodle behaviour, so I think fixes #193 [also #162?].  I'm not sure if breaks something though, because I'm not sure what the customised code was for.