### PR TITLE
MBS-9822: Fix inplace editing

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1116,7 +1116,7 @@ class format_onetopic extends core_courseformat\base {
  * @param mixed $newvalue
  * @return \core\output\inplace_editable
  */
-function format_onetopics_inplace_editable($itemtype, $itemid, $newvalue) {
+function format_onetopic_inplace_editable($itemtype, $itemid, $newvalue) {
     global $DB, $CFG;
     require_once($CFG->dirroot . '/course/lib.php');
     if ($itemtype === 'sectionname' || $itemtype === 'sectionnamenl') {


### PR DESCRIPTION
Inplace editing is not working right now for (sub-)section titles - this is due to a typo in lib.php.

Steps to reproduce (in Moodle 4.5):
* Create a course with format_onetopic
* Create a subsection activity (mod_subsection)
* Click on the subsection title, type something and press enter
* An error message will appear