### PR TITLE
#214 - realcoursedisplay should be initialized in the overridden function

### DIFF
--- a/classes/header.php
+++ b/classes/header.php
@@ -63,9 +63,6 @@ class header implements \renderable, \templatable {
         $format = $this->format;
         $course = $format->get_course();
 
-        // Onetopic format is always multipage.
-        $course->realcoursedisplay = property_exists($course, 'coursedisplay') ? $course->coursedisplay : false;
-
         $firstsection = ($course->realcoursedisplay == COURSE_DISPLAY_MULTIPAGE) ? 1 : 0;
         $currentsection = $format->get_sectionnum();
 

--- a/lib.php
+++ b/lib.php
@@ -210,8 +210,6 @@ class format_onetopic extends core_courseformat\base {
 
                 $course = $this->get_course();
 
-                // Onetopic format is always multipage.
-                $course->realcoursedisplay = property_exists($course, 'coursedisplay') ? $course->coursedisplay : false;
                 $numsections = (int)$DB->get_field('course_sections', 'MAX(section)', ['course' => $courseid], MUST_EXIST);
 
                 if ($section >= 0 && $numsections >= $section) {
@@ -369,6 +367,21 @@ class format_onetopic extends core_courseformat\base {
      */
     public function get_sectionid(): ?int {
         return null;
+    }
+
+    /**
+     * Returns a record from course database table plus additional fields (realcoursedisplay)
+     * Initialization of realcoursedisplay prevents the error if this field was not set before use.
+     *
+     * @return ?stdClass
+     */
+    public function get_course(): ?stdClass {
+        $course = parent::get_course();
+        if (!is_null($course)) {
+            // Onetopic format is always multipage.
+            $course->realcoursedisplay = property_exists($course, 'coursedisplay') ? $course->coursedisplay : false;
+        }
+        return $course;
     }
 
     /**


### PR DESCRIPTION
The additional field `realcoursedisplay ` should be initialized in the overridden function `get_course` to ensure that `realcoursedisplay ` is never used before it has been set.