### PR TITLE
Deprecate max sections setting (MDL-84291)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -266,6 +266,16 @@ class format_onetopic extends core_courseformat\base {
     }
 
     /**
+     * Method used to get the maximum number of sections for this course format.
+     *
+     * @return int
+     */
+    public function get_max_sections(): int {
+        global $CFG;
+        return ($CFG->version >= 2025060500) ? PHP_INT_MAX : parent::get_max_sections();
+    }
+
+    /**
      * Returns true if this course format uses sections.
      *
      * @return bool


### PR DESCRIPTION
The max sections setting is deprecated in Moodle 5.1, and AFAIK there is now no limit on the number of sections that can be added in the core formats.  However, plugin formats get limited to 52 sections by default, for some reason.  This patch removes that section limit in Moodle 5.1.