### PR TITLE
replaced deprecated core string 'hiddensections_help' 

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -87,7 +87,7 @@ if ($ADMIN->fulltree) {
         new admin_setting_configselect(
             'format_onetopic/defaulthiddensections',
             get_string('hiddensections'),
-            get_string('hiddensections_help'),
+            get_string('hiddensectionshelp', 'format_onetopic'),
             \format_onetopic::HIDDENSENTIONS_HELP,
             $options
         )


### PR DESCRIPTION
Core string 'hiddensections_help' is deprecated since Moodle 5.1, throwing an exception.
I have replaced it with local string 'hiddensectionshelp' if that fits?