### PR TITLE
#235 Add cache headers for /course/format/onetopic/styles.php

### DIFF
--- a/classes/local/hooks/output/before_http_headers.php
+++ b/classes/local/hooks/output/before_http_headers.php
@@ -30,7 +30,38 @@ class before_http_headers {
      * @param \core\hook\output\before_http_headers $unused
      */
     public static function callback(\core\hook\output\before_http_headers $unused): void {
-        global $PAGE;
-        $PAGE->requires->css('/course/format/onetopic/styles.php');
+        global $PAGE, $COURSE;
+
+        // Don't require styles script if the course format isn't 'onetopic'.
+        if ($PAGE->course && isset($COURSE->id) && $COURSE->format == 'onetopic') {
+
+            // Check if site-wide tab styles are configured, if not, do nothing.
+            if (!get_config('format_onetopic', 'tabstyles')) {
+                return;
+            }
+
+            $revision = self::get_tabstyles_revision();
+            $PAGE->requires->css(new \moodle_url('/course/format/onetopic/styles.php', [
+                'revision' => $revision,
+            ]));
+        }
+    }
+
+    /**
+     * Generates an 8-character hash from the tab styles configuration.
+     * When styles change, the hash changes, creating a new URL that
+     * busts the cache.
+     *
+     * @return string
+     */
+    public static function get_tabstyles_revision(): string {
+        $tabstyles = get_config('format_onetopic', 'tabstyles');
+
+        if (empty($tabstyles)) {
+            return '0';
+        }
+
+        // Use first 8 chars of md5 hash as revision.
+        return substr(md5($tabstyles), 0, 8);
     }
 }

--- a/styles.php
+++ b/styles.php
@@ -28,8 +28,7 @@ define('NO_MOODLE_COOKIES', true);
 // phpcs:disable moodle.Files.RequireLogin.Missing
 require_once('../../../config.php');
 
-@header('Content-Disposition: inline; filename="styles.php"');
-@header('Content-Type: text/css; charset=utf-8');
+$revision = optional_param('revision', 0, PARAM_ALPHANUM);
 
 $withunits = ['font-size', 'line-height', 'margin', 'padding', 'border-width', 'border-radius'];
 $csscontent = '';
@@ -131,5 +130,38 @@ if (!empty($tabstyles)) {
         $csstabstyles = preg_replace('/<[^>]*>/', '', $csscontent);
     }
 }
+
+$csstabstyles = trim($csstabstyles);
+$etag = md5($csstabstyles . $revision);
+
+// ETag validation: Return 304 if client has the current version. This will
+// preserve the existing cache for $cache_lifetime.
+if (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+    $clientetag = trim($_SERVER['HTTP_IF_NONE_MATCH'], '"');
+    if ($clientetag === $etag) {
+        header('HTTP/1.1 304 Not Modified');
+        header('ETag: "' . $etag . '"');
+        exit;
+    }
+}
+
+// Return empty response for edge cases (no styles configured & direct URL access).
+if (empty($csstabstyles)) {
+    header('HTTP/1.1 304 Not Modified');
+    header('Content-Length: 0');
+    exit;
+}
+
+// Cache for 1 year, this is safe due to cache busting via revision param.
+$cache_lifetime = 31536000;
+header('Cache-Control: public, max-age=' . $cache_lifetime . ', immutable');
+header('Expires: ' . gmdate('D, d M Y H:i:s', time() + $cache_lifetime) . ' GMT');
+header('ETag: "' . $etag . '"');
+
+// Content headers.
+header('Content-Length: ' . strlen($csstabstyles));
+header('Content-Disposition: inline; filename="styles.php"');
+header('Content-Type: text/css; charset=utf-8');
+header('X-Content-Type-Options: nosniff');
 
 echo $csstabstyles;

--- a/tests/styles_caching_test.php
+++ b/tests/styles_caching_test.php
@@ -1,0 +1,107 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace format_onetopic;
+
+use format_onetopic\local\hooks\output\before_http_headers;
+
+/**
+ * Tests for styles.php caching functionality.
+ *
+ * @package   format_onetopic
+ * @author    Jonathan Archer <jonathanarcher@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \format_onetopic\local\hooks\output\before_http_headers::get_tabstyles_revision
+ */
+class styles_caching_test extends \advanced_testcase {
+
+    /**
+     * Test revision is '0' when no tab styles configured.
+     */
+    public function test_revision_empty_when_no_styles(): void {
+        $this->resetAfterTest(true);
+
+        set_config('tabstyles', '', 'format_onetopic');
+
+        $revision = before_http_headers::get_tabstyles_revision();
+        $this->assertEquals('0', $revision);
+    }
+
+    /**
+     * Test revision is valid hash when tab styles exist.
+     */
+    public function test_revision_is_hash_when_styles_exist(): void {
+        $this->resetAfterTest(true);
+
+        $tabstyles = json_encode(['default' => ['color' => 'red']]);
+        set_config('tabstyles', $tabstyles, 'format_onetopic');
+
+        $revision = before_http_headers::get_tabstyles_revision();
+
+        $this->assertIsString($revision);
+        $this->assertEquals(8, strlen($revision));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{8}$/', $revision);
+    }
+
+    /**
+     * Test revision changes when tab styles change.
+     */
+    public function test_revision_changes_when_styles_change(): void {
+        $this->resetAfterTest(true);
+
+        $tabstyles1 = json_encode(['default' => ['color' => 'red']]);
+        set_config('tabstyles', $tabstyles1, 'format_onetopic');
+        $revision1 = before_http_headers::get_tabstyles_revision();
+
+        $tabstyles2 = json_encode(['default' => ['color' => 'blue']]);
+        set_config('tabstyles', $tabstyles2, 'format_onetopic');
+        $revision2 = before_http_headers::get_tabstyles_revision();
+
+        $this->assertNotEquals($revision1, $revision2);
+    }
+
+    /**
+     * Test revision stays same for identical styles.
+     */
+    public function test_revision_consistent_for_same_styles(): void {
+        $this->resetAfterTest(true);
+
+        $tabstyles = json_encode(['default' => ['color' => 'red']]);
+        set_config('tabstyles', $tabstyles, 'format_onetopic');
+
+        $revision1 = before_http_headers::get_tabstyles_revision();
+        $revision2 = before_http_headers::get_tabstyles_revision();
+
+        $this->assertEquals($revision1, $revision2);
+    }
+
+    /**
+     * Test revision is deterministic (same input = same hash).
+     */
+    public function test_revision_is_deterministic(): void {
+        $this->resetAfterTest(true);
+
+        $tabstyles = json_encode(['default' => ['color' => 'red']]);
+        set_config('tabstyles', $tabstyles, 'format_onetopic');
+
+        $expected = substr(md5($tabstyles), 0, 8);
+        $actual = before_http_headers::get_tabstyles_revision();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+}


### PR DESCRIPTION
Fixes #235

Implemented browser and CDN-level caching with cache-busting using revision query param. Additionally if there aren't default tab styles the `styles.php` will not be required through the `before_http_headers` hook, preventing unnecessary requests. 

### Testing
Added unit tests covering revision version function:
```
root@aaaaaaaaaa:/var/www/mdl-45-test# vendor/bin/phpunit --testsuite format_onetopic_testsuite
Moodle 4.5.8+ (Build: 20251212), 3b42f965b5248b307ce49192d48f99d161c452fc
Php: 8.3.25, pgsql: 17.4 (Debian 17.4-1.pgdg120+2), OS: Linux 6.14.0-37-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

......                                                              6 / 6 (100%)

Time: 00:00.590, Memory: 68.50 MB

OK (6 tests, 8 assertions)
```
