### PR TITLE
MBS-10517: hide subtopics when parent section is hidden

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1205,20 +1205,20 @@ class format_onetopic extends core_courseformat\base {
     public function section_get_available_hook(section_info $section, &$available, &$availableinfo) {
 
         // Only check childs tabs visibility.
-        if (!isset($section->level) || (int)$section->level === 0) {
+        if (!isset($section->level) || $section->level == 0) {
             return;
         }
 
-        // The tab visibility depends on parent user visibility.
+        // The tab visibility depend of parent visibility.
         $parentsections = $this->fot_get_sections_extra();
-        $parent = $parentsections[$section->section] ?? null;
-        if (!$parent) {
-            return;
-        }
-
-        if (!$parent->uservisible) {
-            $available = false;
-            $availableinfo = '';
+        $parent = $parentsections[$section->section];
+        if ($parent) {
+            if (!($parent->visible && $parent->available)) {
+                $available = false;
+                if (!$parent->uservisible) {
+                    $availableinfo = '';
+                }
+            }
         }
     }
 

--- a/tests/behat/edit_delete_sections.feature
+++ b/tests/behat/edit_delete_sections.feature
@@ -6,9 +6,8 @@ Feature: Sections can be edited and deleted in Onetopic format
 
   Background:
     Given the following "users" exist:
-      | username | firstname | lastname | email                |
+      | username | firstname | lastname | email            |
       | teacher1 | Teacher   | 1        | teacher1@example.com |
-      | student1 | Student   | 1        | student1@example.com |
     And the following "courses" exist:
       | fullname | shortname | format   | coursedisplay | numsections |
       | Course 1 | C1        | onetopic | 0             | 5           |
@@ -21,7 +20,6 @@ Feature: Sections can be edited and deleted in Onetopic format
     And the following "course enrolments" exist:
       | user     | course | role           |
       | teacher1 | C1     | editingteacher |
-      | student1 | C1     | student        |
     And I log in as "teacher1"
 
   Scenario: View the default name of the general section in Onetopic format
@@ -57,22 +55,6 @@ Feature: Sections can be edited and deleted in Onetopic format
       | Section name      | This is the second topic |
     Then I should see "This is the second topic" in the ".format_onetopic-tabs .tab_position_2 .nav-link.active" "css_element"
     And I should not see "Topic 2" in the ".format_onetopic-tabs .tab_position_2 .nav-link.active" "css_element"
-
-  @javascript
-  Scenario: Subtopics of hidden parent sections are not visible to students
-    Given I am on "Course 1" course homepage with editing mode on
-    And I edit the section "2" and I fill the form with:
-      | Level | Child of previous tab |
-    And I edit the section "4" and I fill the form with:
-      | Level | Child of previous tab |
-    And I edit the section "3" and I fill the form with:
-      | Visible | Hide on course page |
-    And I log out
-    And I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I click on "Topic 1" "link" in the "#page-content ul.nav.nav-tabs" "css_element"
-    Then I should see "Topic 2" in the "#page-content .onetopic-tab-body" "css_element"
-    And I should not see "Topic 4" in the "#page-content .onetopic-tab-body" "css_element"
 
   Scenario: Deleting the last section in Onetopic format
     Given I am on "Course 1" course homepage with editing mode on

--- a/tests/behat/subtopics_visibility.feature
+++ b/tests/behat/subtopics_visibility.feature
@@ -1,0 +1,33 @@
+@format @format_onetopic
+Feature: Subtopics of hidden parent sections are not visible to students
+  In order to keep subtopics aligned with their parents
+  As a student I should not see subtopics of hidden parent sections
+
+  Background:
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@example.com |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | format   | coursedisplay | numsections |
+      | Course 1 | C1        | onetopic | 0             | 5           |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And I log in as "teacher1"
+
+  Scenario: Subtopics of hidden parent sections are not visible to students
+    Given I am on "Course 1" course homepage with editing mode on
+    And I edit the section "2" and I fill the form with:
+      | Level | Child of previous tab |
+    And I edit the section "4" and I fill the form with:
+      | Level | Child of previous tab |
+    And I edit the section "3" and I fill the form with:
+      | Visible | Hide on course page |
+    And I log out
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I click on "Topic 1" "link" in the "#page-content ul.nav.nav-tabs" "css_element"
+    Then I should see "Topic 2" in the "#page-content .onetopic-tab-body" "css_element"
+    And I should not see "Topic 4" in the "#page-content .onetopic-tab-body" "css_element"


### PR DESCRIPTION
The patch solves issue #243 and ensures that subtopics are treated as not available for students when their parent section is not user‑visible, preventing hidden parent sections from leaking their subtopics into the previous visible section. 
It applies the parent visibility rule in the format’s availability hook and adds a Behat scenario covering the student‑view regression