### PR TITLE
Subsection options patch

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -862,12 +862,7 @@ class format_onetopic extends core_courseformat\base {
      * @return array
      */
     public function section_format_options($foreditform = false) {
-        global $section;
-
         static $sectionformatoptions = false;
-
-        // Diferent format options for subsection activity modules.
-        $subsection = !empty($section->component);
 
         $onetopicconfig = get_config('format_onetopic');
 
@@ -919,6 +914,10 @@ class format_onetopic extends core_courseformat\base {
         }
 
         if ($foreditform) {
+            // Different format options for subsection activity modules.
+            global $section;
+            $subsection = !empty($section->component);
+
             $sectionformatoptionsedit = [];
 
             if ($subsection) {
@@ -1008,7 +1007,7 @@ class format_onetopic extends core_courseformat\base {
                 }
             }
 
-            $sectionformatoptions = $sectionformatoptionsedit;
+            return $sectionformatoptionsedit;
         }
 
         return $sectionformatoptions;
@@ -1203,14 +1202,8 @@ class format_onetopic extends core_courseformat\base {
      * @param string $availableinfo the 'availableinfo' propery of the section_info as it was evaluated by conditional availability.
      */
     public function section_get_available_hook(section_info $section, &$available, &$availableinfo) {
-        try {
-            $level = $section->level;
-        } catch (Exception $notused) {
-            return;
-        }
-
         // Only check childs tabs visibility.
-        if (empty($level)) {
+        if (!empty($section->component) || ($section->level == 0)) {
             return;
         }
 


### PR DESCRIPTION
There still seems to be a minor issue with the fix for #243 .  With debug mode on, when editing a subsection, I see warning messages.

I think I see how the code works now, and have some suggestions.

I think global $section is only defined when displaying the edit form, so should probably only be referenced in this case.

I think this assignment is an issue:
$sectionformatoptions = $sectionformatoptionsedit;
This means that after the modified edit form options are requested, later calls will return the modified edit form options, even if they're not requested.  This is what's causing the warnings, I think.

The final change doesn't make any difference to the result, I think, but is a simpler way.