### PR TITLE
MBS-10936: Undo sticky nav for mobile and vertical submenu

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -98,8 +98,6 @@
 .format-onetopic .verticaltabs > .tabs-wrapper {
     width: 250px;
     border-bottom: none;
-    position: sticky;
-    top: calc(var(--navbar-height, 60px) + 1px);
     z-index: 3;
 }
 
@@ -702,8 +700,6 @@
     }
 
     .format-onetopic .onetopic-tab-body .format_onetopic-tabs {
-        position: sticky;
-        top: calc(var(--navbar-height, 60px) + 51px);
         z-index: 2;
         background-color: var(--bglight, #e9ecef);
         padding: 5px;

--- a/styles.css
+++ b/styles.css
@@ -571,9 +571,6 @@
 
 @media (min-width: 601px) {
     .format-onetopic .verticaltabs .onetopic-tab-body .format_onetopic-tabs {
-        position: sticky;
-        top: calc(var(--navbar-height, 60px) + 1px);
-        z-index: 2;
         background-color: var(--white, #fff);
         outline: 5px solid var(--white, #fff);
     }
@@ -587,8 +584,7 @@
 
 @media (max-width: 600px) {
     .format-onetopic .tabs-wrapper {
-        position: sticky;
-        top: calc(var(--navbar-height, 60px) + 2px);
+        position: relative;
         z-index: 3;
         display: flex;
         flex-wrap: wrap;


### PR DESCRIPTION
Hi David,
we were told some teachers use extensive submenu´s that made it difficult to use, especially on smaller devices.
This is why we decided to undo the sticky vertical submenues and sticky small device menu.
If you want to have, this would be the PR for it.

Have a nice Day and best regards
Tobi